### PR TITLE
Fix missing initialisation in gdisp()

### DIFF
--- a/lib/core.f90
+++ b/lib/core.f90
@@ -976,6 +976,7 @@ contains
     dc6i=0.0d0
     abccalc=.FALSE.
     abcthr=cn_thr
+    eabc = 0.0d0
 
     xyzTmp = xyz
 


### PR DESCRIPTION
Missing initialization. It triggers a runtime error when executed from DFTB+ compiled with Intel 17 in debug mode.